### PR TITLE
Release actions/workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,8 @@ jobs:
   win-build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/cache@v4
+      - name: Cache OBS Studio Executable
+        uses: actions/cache@v4
         id: cache
         with:
           path: C:/Program Files/obs-studio/bin/64bit/obs64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: release
+
+on:
+  push:
+    branches:
+      - release
+    tags:
+      - 'v*.*.*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt-get install libudev-dev libxtst-dev libxext-dev xorg-dev libinput-dev libobs-dev
+      - name: Build
+        run: |
+          cargo build --release
+
+      - name: Upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: keystroke-display-ubuntu
+          path: target/release/
+
+  win-build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: C:/Program Files/obs-studio/bin/64bit/obs64.exe
+          key: ${{ runner.os }}-obs-studio
+
+      - name: Install OBS Studio
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: choco install obs-studio
+
+      - name: Build
+        run: |
+          cargo build --release
+
+      - name: Upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: keystroke-display-windows
+          path: target/release/
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [ubuntu-build, win-build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: target/release/
+
+      - name: Create ZIP files for Ubuntu
+        run: |
+          cd target/release/keystroke-display-ubuntu
+          zip -r keystroke-display-ubuntu.zip *
+
+      - name: Create ZIP files for Windows
+        run: |
+          cd target/release/keystroke-display-windows
+          zip -r keystroke-display-windows.zip *
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          files: |
+            target/release/keystroke-display-ubuntu/keystroke-display-ubuntu.zip
+            target/release/keystroke-display-windows/keystroke-display-windows.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
   win-build:
     runs-on: windows-latest
     steps:
-      - name: Cache OBS Studio Executable
-        uses: actions/cache@v4
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           path: C:/Program Files/obs-studio/bin/64bit/obs64.exe

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,8 +2,6 @@ name: Rust
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
     branches: ['main']
   pull_request:
     branches: ['main']

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,11 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    tags:
+      - 'v*.*.*'
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #10

Actions will build when pushed to main, just the rust.yml action which tests build.

Will need to make a new branch "release", and when pushed to release it will build as well. It will not release unless a new version tag is added to the local repo and pushed to release.

This also caches OBS download, downloading via choco occasionally likes to fail.

e.g.
```
// Build action will run, but will not release on push. 
git add .
git commit -m "blah"
git push
```
```
// Add new tag to initiate a full action run, which will build and upload release binaries for the standalone build.
git tag v0.1.0
git push origin release v0.1.0
```

You will also need to set up a developer API token, give it Actions read/write and contents read/write

[api perms](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-actions)
[action release repo](https://github.com/softprops/action-gh-release?tab=readme-ov-file)

Create your token, then go to the keystroke repo, settings tab, Secrets and Variables section, Action sub section. Create a new repository secret called GH_TOKEN and paste the api key with correct permissions and save.

