### PR TITLE
Release zips for plugin and standalone separately, and to include overlay folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,38 +20,44 @@ jobs:
         run: |
           cargo build --release
 
-      - name: Upload-artifacts
+      - name: Upload-artifacts-standalone
         uses: actions/upload-artifact@v4
         with:
-          name: keystroke-display-ubuntu
+          name: keystroke-display-standalone-ubuntu
           path: |
             target/release/keystroke-overlay-standalone
+
+      - name: Upload-artifacts-plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: keystroke-display-plugin-ubuntu
+          path: |
             target/release/libkeystroke_overlay.so
 
   win-build:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: C:/Program Files/obs-studio/bin/64bit/obs64.exe
-          key: ${{ runner.os }}-obs-studio
 
       - name: Install OBS Studio
-        if: steps.cache.outputs.cache-hit != 'true'
         run: choco install obs-studio
 
       - name: Build
         run: |
           cargo build --release
 
-      - name: Upload-artifacts
+      - name: Upload-artifacts-standalone
         uses: actions/upload-artifact@v4
         with:
-          name: keystroke-display-windows
+          name: keystroke-display-standalone-windows
           path: |
             target/release/keystroke-overlay-standalone.exe
+      
+      - name: Upload-artifacts-plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: keystroke-display-plugin-windows
+          path: |
             target/release/keystroke-overlay-standalone.dll
 
   release:
@@ -68,18 +74,30 @@ jobs:
       
       - name: Copy overlay folder
         run: |
-          cp -r overlay/ target/release/keystroke-display-ubuntu
-          cp -r overlay/ target/release/keystroke-display-windows
+          cp -r overlay/ target/release/keystroke-display-standalone-ubuntu
+          cp -r overlay/ target/release/keystroke-display-plugin-ubuntu
+          cp -r overlay/ target/release/keystroke-display-standalone-windows
+          cp -r overlay/ target/release/keystroke-display-plugin-windows
 
-      - name: Create ZIP files for Ubuntu
+      - name: Create ZIP files for Ubuntu Standalone
         run: |
-          cd target/release/keystroke-display-ubuntu
+          cd target/release/keystroke-display-standalone-ubuntu
           zip -r keystroke-display-ubuntu.zip *
-
-      - name: Create ZIP files for Windows
+      
+      - name: Create ZIP files for Ubuntu Plugin
         run: |
-          cd target/release/keystroke-display-windows
+          cd target/release/keystroke-display-plugin-ubuntu
+          zip -r keystroke-display-plugin-ubuntu.zip *
+
+      - name: Create ZIP files for Windows Standalone
+        run: |
+          cd target/release/keystroke-display-standalone-windows
           zip -r keystroke-display-windows.zip *
+      
+      - name: Create ZIP files for Windows Plugin
+        run: |
+          cd target/release/keystroke-display-plugin-windows
+          zip -r keystroke-display-plugin-windows.zip *
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: keystroke-display-ubuntu
-          path: target/release/
+          path: |
+            target/release/keystroke-overlay-standalone
+            target/release/libkeystroke_overlay.so
 
   win-build:
     runs-on: windows-latest
@@ -48,7 +50,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: keystroke-display-windows
-          path: target/release/
+          path: |
+            target/release/keystroke-overlay-standalone.exe
+            target/release/keystroke-overlay-standalone.dll
 
   release:
     runs-on: ubuntu-latest
@@ -61,6 +65,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: target/release/
+      
+      - name: Copy overlay folder
+        run: |
+          cp -r overlay/ target/release/keystroke-display-ubuntu
+          cp -r overlay/ target/release/keystroke-display-windows
 
       - name: Create ZIP files for Ubuntu
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           files: |
-            target/release/keystroke-display-ubuntu/keystroke-display-standalone-ubuntu.zip
-            target/release/keystroke-display-ubuntu/keystroke-display-plugin-ubuntu.zip
-            target/release/keystroke-display-windows/keystroke-display-standalone-windows.zip
-            target/release/keystroke-display-windows/keystroke-display-plugin-windows.zip
+            target/release/keystroke-display-standalone-ubuntu/keystroke-display-standalone-ubuntu.zip
+            target/release/keystroke-display-plugin-ubuntu/keystroke-display-plugin-ubuntu.zip
+            target/release/keystroke-display-standalone-windows/keystroke-display-standalone-windows.zip
+            target/release/keystroke-display-plugin-windows/keystroke-display-plugin-windows.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Create ZIP files for Ubuntu Standalone
         run: |
           cd target/release/keystroke-display-standalone-ubuntu
-          zip -r keystroke-display-ubuntu.zip *
+          zip -r keystroke-display-standalone-ubuntu.zip *
       
       - name: Create ZIP files for Ubuntu Plugin
         run: |
@@ -92,7 +92,7 @@ jobs:
       - name: Create ZIP files for Windows Standalone
         run: |
           cd target/release/keystroke-display-standalone-windows
-          zip -r keystroke-display-windows.zip *
+          zip -r keystroke-display-standalone-windows.zip *
       
       - name: Create ZIP files for Windows Plugin
         run: |
@@ -105,5 +105,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           files: |
-            target/release/keystroke-display-ubuntu/keystroke-display-ubuntu.zip
-            target/release/keystroke-display-windows/keystroke-display-windows.zip
+            target/release/keystroke-display-ubuntu/keystroke-display-standalone-ubuntu.zip
+            target/release/keystroke-display-ubuntu/keystroke-display-plugin-ubuntu.zip
+            target/release/keystroke-display-windows/keystroke-display-standalone-windows.zip
+            target/release/keystroke-display-windows/keystroke-display-plugin-windows.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           name: keystroke-display-plugin-windows
           path: |
-            target/release/keystroke-overlay-standalone.dll
+            target/release/keystroke_overlay.dll
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,5 @@
 name: Rust
 
-
-
 on:
   push:
     branches: ['main']


### PR DESCRIPTION
closes #8 
PR for release action to build for standalone and plugin (for both windows and ubuntu) independently, as well as include the overlay folder in the zip for each.

Also removed cache step for windows OBS download. Caused more problems than solved.